### PR TITLE
fix: change regex for content-type checking to also allow media-type params

### DIFF
--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -381,7 +381,7 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
             JsonNode jsonEventDataOrNull = null;
 
             var dataContentType = publishedEventMessage.getEvent().getDataContentType();
-            var jsonMediaTypeRegexPattern = Pattern.compile("^application/(?:[a-zA-Z0-9]+\\+)?json(;.*)?", Pattern.CASE_INSENSITIVE);
+            var jsonMediaTypeRegexPattern = Pattern.compile("^application/(?:[a-zA-Z0-9]+\\+)?json.*", Pattern.CASE_INSENSITIVE);
 
             if (eventData != null && (dataContentType == null || jsonMediaTypeRegexPattern.matcher(dataContentType.trim()).matches())) {
                 jsonEventDataOrNull = parseEventData(eventData);

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -381,7 +381,7 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
             JsonNode jsonEventDataOrNull = null;
 
             var dataContentType = publishedEventMessage.getEvent().getDataContentType();
-            var jsonMediaTypeRegexPattern = Pattern.compile("^application/(?:[a-zA-Z0-9]+\\+)?json$", Pattern.CASE_INSENSITIVE);
+            var jsonMediaTypeRegexPattern = Pattern.compile("^application/(?:[a-zA-Z0-9]+\\+)?json(;.*)?", Pattern.CASE_INSENSITIVE);
 
             if (eventData != null && (dataContentType == null || jsonMediaTypeRegexPattern.matcher(dataContentType.trim()).matches())) {
                 jsonEventDataOrNull = parseEventData(eventData);


### PR DESCRIPTION
This PR fixes a bug that occurred when the content-type headers didn't match the previous content-type regex and lead to the filters not being applied.