### PR TITLE
feat(hazelcast): move from embedded Hazelcast to dedicated setup with MongoDB fallback

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 httpClientVersion=4.5.14
-horizonParentVersion=4.1.0
+horizonParentVersion=0.0.0-feature-hazelcast-standalone-cache-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 httpClientVersion=4.5.14
-horizonParentVersion=0.0.0-feature-hazelcast-mongo-failover-SNAPSHOT
+horizonParentVersion=5.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 httpClientVersion=4.5.14
-horizonParentVersion=0.0.0-feature-hazelcast-standalone-cache-SNAPSHOT
+horizonParentVersion=0.0.0-feature-hazelcast-mongo-failover-SNAPSHOT

--- a/src/main/java/de/telekom/horizon/galaxy/cache/SubscriptionCountGaugeCache.java
+++ b/src/main/java/de/telekom/horizon/galaxy/cache/SubscriptionCountGaugeCache.java
@@ -45,7 +45,7 @@ public class SubscriptionCountGaugeCache {
         return Tags.of(
                 TAG_ENVIRONMENT, environment,
                 TAG_EVENT_TYPE, resource.getSpec().getSubscription().getType(),
-                TAG_DELIVERY_TYPE, resource.getSpec().getSubscription().getDeliveryType().equalsIgnoreCase("callback") ? "callback" : "sse",
+                TAG_DELIVERY_TYPE, resource.getSpec().getSubscription().getDeliveryType().equalsIgnoreCase("callback") ? "callback" : "server_sent_event",
                 TAG_SUBSCRIBER_ID, resource.getSpec().getSubscription().getSubscriberId());
     }
 

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import static de.telekom.eni.pandora.horizon.metrics.HorizonMetricsConstants.METRIC_MULTIPLEXED_EVENTS;
-import static de.telekom.eni.pandora.horizon.metrics.HorizonMetricsConstants.TAG_CALLBACK_URL;
 
 /**
  * The {@code PublishedMessageTask} class is responsible for handling a single {@link PublishedEventMessage}.

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import static de.telekom.eni.pandora.horizon.metrics.HorizonMetricsConstants.METRIC_MULTIPLEXED_EVENTS;
+import static de.telekom.eni.pandora.horizon.metrics.HorizonMetricsConstants.TAG_CALLBACK_URL;
 
 /**
  * The {@code PublishedMessageTask} class is responsible for handling a single {@link PublishedEventMessage}.
@@ -224,8 +225,12 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
                 sendFailedStatusMessage(subscriptionEventMessage);
                 trackEventForDeduplication(subscriptionEventMessage);
             } finally {
+                var tags = metricsHelper.buildTagsFromSubscriptionEventMessage(subscriptionEventMessage);
+                if (subscriptionEventMessage.getDeliveryType().equals(DeliveryType.SERVER_SENT_EVENT)) {
+                    tags = tags.and(TAG_CALLBACK_URL, "none");
+                }
 
-                metricsHelper.getRegistry().counter(METRIC_MULTIPLEXED_EVENTS, metricsHelper.buildTagsFromSubscriptionEventMessage(subscriptionEventMessage)).increment();
+                metricsHelper.getRegistry().counter(METRIC_MULTIPLEXED_EVENTS, tags).increment();
                 multiplexSpan.finish();
 
                 MDC.clear();

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -226,10 +226,6 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
                 trackEventForDeduplication(subscriptionEventMessage);
             } finally {
                 var tags = metricsHelper.buildTagsFromSubscriptionEventMessage(subscriptionEventMessage);
-                if (subscriptionEventMessage.getDeliveryType().equals(DeliveryType.SERVER_SENT_EVENT)) {
-                    tags = tags.and(TAG_CALLBACK_URL, "none");
-                }
-
                 metricsHelper.getRegistry().counter(METRIC_MULTIPLEXED_EVENTS, tags).increment();
                 multiplexSpan.finish();
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,6 +36,11 @@ horizon:
     deDuplication:
       enabled: ${GALAXY_CACHE_DE_DUPLICATION_ENABLED:false}
       defaultCacheName: galaxy-deduplication
+  mongo:
+    enabled: ${GALAXY_MONGO_ENABLED:true}
+    url: ${GALAXY_MONGO_URL:mongodb://root:root@localhost:27017}
+    database: ${GALAXY_MONGO_DATABASE:horizon-config}
+    collection: ${GALAXY_MONGO_COLLECTION:eventSubscriptions}
 
 pandora:
   tracing:
@@ -68,6 +73,8 @@ management:
       enabled: true
   health:
     hazelcast:
+      enabled: false
+    mongo:
       enabled: false
   zipkin:
     tracing:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,7 +39,8 @@ horizon:
   mongo:
     enabled: ${GALAXY_MONGO_ENABLED:true}
     url: ${GALAXY_MONGO_URL:mongodb://root:root@localhost:27017}
-    database: ${GALAXY_MONGO_DATABASE:horizon-config}
+    databases:
+      configTimeDatabase: ${HORIZON_MONGO_CONFIG_DATABASE:horizon-config}
     collection: ${GALAXY_MONGO_COLLECTION:eventSubscriptions}
 
 pandora:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,6 +66,9 @@ management:
       show-details: always
     shutdown:
       enabled: true
+  health:
+    hazelcast:
+      enabled: false
   zipkin:
     tracing:
       endpoint: ${JAEGER_COLLECTOR_URL:http://jaeger-collector.example.com:9411}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,7 +40,7 @@ horizon:
     enabled: ${GALAXY_MONGO_ENABLED:true}
     url: ${GALAXY_MONGO_URL:mongodb://root:root@localhost:27017}
     databases:
-      configTimeDatabase: ${HORIZON_MONGO_CONFIG_DATABASE:horizon-config}
+      configTimeDatabase: ${GALAXY_MONGO_CONFIG_DATABASE:horizon-config}
     collection: ${GALAXY_MONGO_COLLECTION:eventSubscriptions}
 
 pandora:

--- a/src/test/java/de/telekom/horizon/galaxy/service/DeduplicationTests.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/DeduplicationTests.java
@@ -4,6 +4,7 @@
 
 package de.telekom.horizon.galaxy.service;
 
+import com.hazelcast.core.HazelcastInstance;
 import de.telekom.eni.pandora.horizon.cache.service.DeDuplicationService;
 import de.telekom.eni.pandora.horizon.kubernetes.resource.SubscriptionResource;
 import de.telekom.eni.pandora.horizon.model.event.DeliveryType;
@@ -11,14 +12,17 @@ import de.telekom.eni.pandora.horizon.model.event.Event;
 import de.telekom.eni.pandora.horizon.model.event.PublishedEventMessage;
 import de.telekom.eni.pandora.horizon.model.event.SubscriptionEventMessage;
 import de.telekom.horizon.galaxy.utils.AbstractIntegrationTest;
+import de.telekom.horizon.galaxy.utils.HazelcastTestInstance;
 import de.telekom.horizon.galaxy.utils.HorizonTestHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(HazelcastTestInstance.class)
 public class DeduplicationTests extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/de/telekom/horizon/galaxy/service/DeduplicationTests.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/DeduplicationTests.java
@@ -4,7 +4,6 @@
 
 package de.telekom.horizon.galaxy.service;
 
-import com.hazelcast.core.HazelcastInstance;
 import de.telekom.eni.pandora.horizon.cache.service.DeDuplicationService;
 import de.telekom.eni.pandora.horizon.kubernetes.resource.SubscriptionResource;
 import de.telekom.eni.pandora.horizon.model.event.DeliveryType;

--- a/src/test/java/de/telekom/horizon/galaxy/service/EmptyRecipientsTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/EmptyRecipientsTest.java
@@ -8,8 +8,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import de.telekom.eni.pandora.horizon.model.event.Event;
 import de.telekom.eni.pandora.horizon.model.event.PublishedEventMessage;
 import de.telekom.horizon.galaxy.utils.AbstractIntegrationTest;
+import de.telekom.horizon.galaxy.utils.HazelcastTestInstance;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.Map;
@@ -18,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-
+@ExtendWith(HazelcastTestInstance.class)
 class EmptyRecipientsTest extends AbstractIntegrationTest {
 
     private final static String TEST_ENVIRONMENT = "playground";

--- a/src/test/java/de/telekom/horizon/galaxy/service/MultisubscriptionTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/MultisubscriptionTest.java
@@ -12,9 +12,11 @@ import de.telekom.eni.pandora.horizon.model.event.PublishedEventMessage;
 import de.telekom.eni.pandora.horizon.model.event.Status;
 import de.telekom.eni.pandora.horizon.model.event.SubscriptionEventMessage;
 import de.telekom.horizon.galaxy.utils.AbstractIntegrationTest;
+import de.telekom.horizon.galaxy.utils.HazelcastTestInstance;
 import de.telekom.horizon.galaxy.utils.HorizonTestHelper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
@@ -24,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(HazelcastTestInstance.class)
 class MultisubscriptionTest extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/de/telekom/horizon/galaxy/service/PublishedInvalidJsonAckTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/PublishedInvalidJsonAckTest.java
@@ -5,8 +5,10 @@
 package de.telekom.horizon.galaxy.service;
 
 import de.telekom.horizon.galaxy.utils.AbstractIntegrationTest;
+import de.telekom.horizon.galaxy.utils.HazelcastTestInstance;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -15,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@ExtendWith(HazelcastTestInstance.class)
 class PublishedInvalidJsonAckTest extends AbstractIntegrationTest {
 
 

--- a/src/test/java/de/telekom/horizon/galaxy/service/ResponseFilterHandlingTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/ResponseFilterHandlingTest.java
@@ -8,9 +8,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import de.telekom.eni.pandora.horizon.model.event.PublishedEventMessage;
 import de.telekom.eni.pandora.horizon.model.event.Status;
 import de.telekom.horizon.galaxy.utils.AbstractIntegrationTest;
+import de.telekom.horizon.galaxy.utils.HazelcastTestInstance;
 import de.telekom.horizon.galaxy.utils.HorizonTestHelper;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -18,6 +20,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(HazelcastTestInstance.class)
 class ResponseFilterHandlingTest extends AbstractIntegrationTest {
 
     @Test

--- a/src/test/java/de/telekom/horizon/galaxy/service/RetentionTimeTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/RetentionTimeTest.java
@@ -13,9 +13,11 @@ import de.telekom.eni.pandora.horizon.model.event.Status;
 import de.telekom.eni.pandora.horizon.model.event.SubscriptionEventMessage;
 import de.telekom.eni.pandora.horizon.model.meta.EventRetentionTime;
 import de.telekom.horizon.galaxy.utils.AbstractIntegrationTest;
+import de.telekom.horizon.galaxy.utils.HazelcastTestInstance;
 import de.telekom.horizon.galaxy.utils.HorizonTestHelper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -25,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(HazelcastTestInstance.class)
 class RetentionTimeTest extends AbstractIntegrationTest {
 
     private final static String TRACING_HEADER_NAME = "x-b3-traceid";

--- a/src/test/java/de/telekom/horizon/galaxy/service/SelectionFilterHandlingTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/SelectionFilterHandlingTest.java
@@ -11,10 +11,12 @@ import de.telekom.eni.pandora.horizon.model.event.PublishedEventMessage;
 import de.telekom.eni.pandora.horizon.model.event.Status;
 import de.telekom.horizon.galaxy.model.EvaluationResultStatus;
 import de.telekom.horizon.galaxy.utils.AbstractIntegrationTest;
+import de.telekom.horizon.galaxy.utils.HazelcastTestInstance;
 import de.telekom.horizon.galaxy.utils.HorizonTestHelper;
 import de.telekom.jsonfilter.operator.comparison.GreaterEqualOperator;
 import de.telekom.jsonfilter.operator.logic.AndOperator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(HazelcastTestInstance.class)
 class SelectionFilterHandlingTest extends AbstractIntegrationTest {
 
     @Test

--- a/src/test/java/de/telekom/horizon/galaxy/service/SimpleGalaxyIntegrationTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/SimpleGalaxyIntegrationTest.java
@@ -14,9 +14,11 @@ import de.telekom.eni.pandora.horizon.model.event.Status;
 import de.telekom.eni.pandora.horizon.model.event.SubscriptionEventMessage;
 import de.telekom.horizon.galaxy.model.EvaluationResultStatus;
 import de.telekom.horizon.galaxy.utils.AbstractIntegrationTest;
+import de.telekom.horizon.galaxy.utils.HazelcastTestInstance;
 import de.telekom.horizon.galaxy.utils.HorizonTestHelper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
@@ -27,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(HazelcastTestInstance.class)
 class SimpleGalaxyIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired

--- a/src/test/java/de/telekom/horizon/galaxy/utils/HazelcastTestInstance.java
+++ b/src/test/java/de/telekom/horizon/galaxy/utils/HazelcastTestInstance.java
@@ -1,0 +1,32 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.galaxy.utils;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import lombok.Getter;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class HazelcastTestInstance implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
+
+    @Getter
+    private static HazelcastInstance hazelcastInstance;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        if (hazelcastInstance == null) {
+            hazelcastInstance = Hazelcast.newHazelcastInstance();
+        }
+    }
+
+    @Override
+    public void close() {
+        if (hazelcastInstance != null) {
+            hazelcastInstance.shutdown();
+            hazelcastInstance = null;
+        }
+    }
+}


### PR DESCRIPTION
This PR also includes a fix to the metrics generated by Galaxy which replaces the delivery-type `sse` with `server_sent_event` to match the naming in the actual subscriptions.