### PR TITLE
perf: optimize Kafka multiplexer with shared thread pools and backpre…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 httpClientVersion=4.5.14
-horizonParentVersion=5.0.1
+horizonParentVersion=5.1.2
 jsonPathVersion=2.10.0

--- a/src/main/java/de/telekom/horizon/galaxy/config/GalaxyConfig.java
+++ b/src/main/java/de/telekom/horizon/galaxy/config/GalaxyConfig.java
@@ -32,6 +32,10 @@ public class GalaxyConfig {
 
     private long nackSleepDurationMs;
 
+    private long backpressureResumeCheckIntervalMs;
+
+    private double backpressureResumeThreshold;
+
     private String defaultEnvironment;
 
     @Value("${horizon.kafka.consumingTopic}")

--- a/src/main/java/de/telekom/horizon/galaxy/config/GalaxyConfig.java
+++ b/src/main/java/de/telekom/horizon/galaxy/config/GalaxyConfig.java
@@ -26,6 +26,12 @@ public class GalaxyConfig {
 
     private int subscriptionMaxThreadPoolSize;
 
+    private int batchQueueCapacity;
+
+    private int subscriptionQueueCapacity;
+
+    private long nackSleepDurationMs;
+
     private String defaultEnvironment;
 
     @Value("${horizon.kafka.consumingTopic}")

--- a/src/main/java/de/telekom/horizon/galaxy/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/de/telekom/horizon/galaxy/config/kafka/KafkaConsumerConfig.java
@@ -10,6 +10,7 @@ import de.telekom.horizon.galaxy.config.GalaxyConfig;
 import de.telekom.horizon.galaxy.kafka.KafkaConsumerHealthIndicator;
 import de.telekom.horizon.galaxy.kafka.PublishedMessageListener;
 import de.telekom.horizon.galaxy.kafka.PublishedMessageTaskFactory;
+import de.telekom.horizon.galaxy.service.BackpressureHandler;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.errors.AuthenticationException;
@@ -35,6 +36,14 @@ public class KafkaConsumerConfig {
 
     @Value("${horizon.kafka.fatalExceptionHandlingEnabled:true}")
     private boolean fatalExceptionHandlingEnabled;
+
+    @Bean
+    public PublishedMessageListener publishedMessageListener(PublishedMessageTaskFactory publishedMessageTaskFactory,
+                                                             HorizonTracer horizonTracer,
+                                                             GalaxyConfig galaxyConfig,
+                                                             MeterRegistry meterRegistry) {
+        return new PublishedMessageListener(publishedMessageTaskFactory, horizonTracer, galaxyConfig, meterRegistry);
+    }
 
     /**
      * Creates a custom error handler that marks the application as unhealthy when a fatal exception
@@ -82,22 +91,33 @@ public class KafkaConsumerConfig {
             "hazelcastInstance"
     })
     @Bean
-    public ConcurrentMessageListenerContainer<String, String> concurrentMessageListenerContainer(PublishedMessageTaskFactory publishedMessageTaskFactory,
+    public ConcurrentMessageListenerContainer<String, String> concurrentMessageListenerContainer(PublishedMessageListener listener,
                                                                                                  KafkaProperties props,
                                                                                                  ConsumerFactory<String, String> consumerFactory,
                                                                                                  GalaxyConfig galaxyConfig,
-                                                                                                 HorizonTracer horizonTracer,
-                                                                                                 CommonErrorHandler kafkaErrorHandler,
-                                                                                                 MeterRegistry meterRegistry) {
+                                                                                                 BackpressureHandler backpressureHandler,
+                                                                                                 PublishedMessageTaskFactory publishedMessageTaskFactory,
+                                                                                                 CommonErrorHandler kafkaErrorHandler) {
+        // Register backpressure handler as rejection handler on both executors
+        listener.getTaskExecutor().getThreadPoolExecutor().setRejectedExecutionHandler(backpressureHandler);
+        publishedMessageTaskFactory.getSubscriptionTaskExecutor().getThreadPoolExecutor().setRejectedExecutionHandler(backpressureHandler);
+
+        // Set executor references on handler for resume monitoring
+        backpressureHandler.setBatchExecutor(listener.getTaskExecutor());
+        backpressureHandler.setSubscriptionExecutor(publishedMessageTaskFactory.getSubscriptionTaskExecutor());
+
         var containerProperties = new ContainerProperties(galaxyConfig.getConsumingTopic());
         containerProperties.setAckMode(ContainerProperties.AckMode.MANUAL);
-        containerProperties.setMessageListener(new PublishedMessageListener(publishedMessageTaskFactory, horizonTracer, galaxyConfig, meterRegistry));
+        containerProperties.setMessageListener(listener);
         ConcurrentMessageListenerContainer<String, String> listenerContainer = new ConcurrentMessageListenerContainer<>(consumerFactory, containerProperties);
         listenerContainer.setAutoStartup(false);
         listenerContainer.setConcurrency(props.getPartitionCount());
         // bean name is the prefix of kafka consumer thread name
         listenerContainer.setBeanName("kafka-message-listener");
         listenerContainer.setCommonErrorHandler(kafkaErrorHandler);
+
+        backpressureHandler.setListenerContainer(listenerContainer);
+
         return listenerContainer;
     }
 

--- a/src/main/java/de/telekom/horizon/galaxy/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/de/telekom/horizon/galaxy/config/kafka/KafkaConsumerConfig.java
@@ -10,6 +10,7 @@ import de.telekom.horizon.galaxy.config.GalaxyConfig;
 import de.telekom.horizon.galaxy.kafka.KafkaConsumerHealthIndicator;
 import de.telekom.horizon.galaxy.kafka.PublishedMessageListener;
 import de.telekom.horizon.galaxy.kafka.PublishedMessageTaskFactory;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.AuthorizationException;
@@ -86,10 +87,11 @@ public class KafkaConsumerConfig {
                                                                                                  ConsumerFactory<String, String> consumerFactory,
                                                                                                  GalaxyConfig galaxyConfig,
                                                                                                  HorizonTracer horizonTracer,
-                                                                                                 CommonErrorHandler kafkaErrorHandler) {
+                                                                                                 CommonErrorHandler kafkaErrorHandler,
+                                                                                                 MeterRegistry meterRegistry) {
         var containerProperties = new ContainerProperties(galaxyConfig.getConsumingTopic());
         containerProperties.setAckMode(ContainerProperties.AckMode.MANUAL);
-        containerProperties.setMessageListener(new PublishedMessageListener(publishedMessageTaskFactory, horizonTracer, galaxyConfig));
+        containerProperties.setMessageListener(new PublishedMessageListener(publishedMessageTaskFactory, horizonTracer, galaxyConfig, meterRegistry));
         ConcurrentMessageListenerContainer<String, String> listenerContainer = new ConcurrentMessageListenerContainer<>(consumerFactory, containerProperties);
         listenerContainer.setAutoStartup(false);
         listenerContainer.setConcurrency(props.getPartitionCount());

--- a/src/main/java/de/telekom/horizon/galaxy/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/de/telekom/horizon/galaxy/config/kafka/KafkaConsumerConfig.java
@@ -10,7 +10,6 @@ import de.telekom.horizon.galaxy.config.GalaxyConfig;
 import de.telekom.horizon.galaxy.kafka.KafkaConsumerHealthIndicator;
 import de.telekom.horizon.galaxy.kafka.PublishedMessageListener;
 import de.telekom.horizon.galaxy.kafka.PublishedMessageTaskFactory;
-import de.telekom.horizon.galaxy.service.BackpressureHandler;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.errors.AuthenticationException;
@@ -95,17 +94,7 @@ public class KafkaConsumerConfig {
                                                                                                  KafkaProperties props,
                                                                                                  ConsumerFactory<String, String> consumerFactory,
                                                                                                  GalaxyConfig galaxyConfig,
-                                                                                                 BackpressureHandler backpressureHandler,
-                                                                                                 PublishedMessageTaskFactory publishedMessageTaskFactory,
                                                                                                  CommonErrorHandler kafkaErrorHandler) {
-        // Register backpressure handler as rejection handler on both executors
-        listener.getTaskExecutor().getThreadPoolExecutor().setRejectedExecutionHandler(backpressureHandler);
-        publishedMessageTaskFactory.getSubscriptionTaskExecutor().getThreadPoolExecutor().setRejectedExecutionHandler(backpressureHandler);
-
-        // Set executor references on handler for resume monitoring
-        backpressureHandler.setBatchExecutor(listener.getTaskExecutor());
-        backpressureHandler.setSubscriptionExecutor(publishedMessageTaskFactory.getSubscriptionTaskExecutor());
-
         var containerProperties = new ContainerProperties(galaxyConfig.getConsumingTopic());
         containerProperties.setAckMode(ContainerProperties.AckMode.MANUAL);
         containerProperties.setMessageListener(listener);
@@ -115,8 +104,6 @@ public class KafkaConsumerConfig {
         // bean name is the prefix of kafka consumer thread name
         listenerContainer.setBeanName("kafka-message-listener");
         listenerContainer.setCommonErrorHandler(kafkaErrorHandler);
-
-        backpressureHandler.setListenerContainer(listenerContainer);
 
         return listenerContainer;
     }
@@ -132,10 +119,10 @@ public class KafkaConsumerConfig {
             return false;
         }
         if (exception instanceof InterruptedException ||
-            exception instanceof InterruptException ||
-            exception instanceof AuthenticationException ||
-            exception instanceof AuthorizationException ||
-            exception instanceof FencedInstanceIdException) {
+                exception instanceof InterruptException ||
+                exception instanceof AuthenticationException ||
+                exception instanceof AuthorizationException ||
+                exception instanceof FencedInstanceIdException) {
             return true;
         }
         return isFatalException(exception.getCause());

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
@@ -24,7 +24,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * The {@code PublishedMessageListener} class is responsible for processing Kafka messages in batches.
@@ -72,11 +75,11 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
         threadPoolTaskExecutor.setThreadGroupName("batch");
         threadPoolTaskExecutor.setThreadNamePrefix("batch-");
         threadPoolTaskExecutor.afterPropertiesSet();
-        
+
         // Register metrics for the thread pool
-        ExecutorServiceMetrics.monitor(meterRegistry, threadPoolTaskExecutor.getThreadPoolExecutor(), 
-            "batchTaskExecutor", Collections.emptyList());
-        
+        ExecutorServiceMetrics.monitor(meterRegistry, threadPoolTaskExecutor.getThreadPoolExecutor(),
+                "batchTaskExecutor", Collections.emptyList());
+
         return threadPoolTaskExecutor;
     }
 
@@ -151,16 +154,9 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
      * @return The minimum valid index, or -1 if both are -1 (success)
      */
     private int determineNackIndex(int rejectedAtIndex, int taskFailureIndex) {
-        if (rejectedAtIndex >= 0 && taskFailureIndex >= 0) {
-            // Both failures occurred - use the earlier one
-            return Math.min(rejectedAtIndex, taskFailureIndex);
-        } else if (rejectedAtIndex >= 0) {
-            // Only rejection occurred
-            return rejectedAtIndex;
-        } else {
-            // Only task failure occurred (or no failure at all)
-            return taskFailureIndex;
-        }
+        if (rejectedAtIndex < 0) return taskFailureIndex;
+        if (taskFailureIndex < 0) return rejectedAtIndex;
+        return Math.min(rejectedAtIndex, taskFailureIndex);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
@@ -44,7 +44,6 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
     private final ThreadPoolTaskExecutor taskExecutor;
     private final HorizonTracer tracer;
     private final GalaxyConfig galaxyConfig;
-    private final Counter threadPoolSaturatedCounter;
     private final Counter nackCounter;
     private final Counter nackDueToTaskFailureCounter;
 
@@ -55,9 +54,6 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
         this.galaxyConfig = galaxyConfig;
 
         this.taskExecutor = initThreadPoolTaskExecutor(galaxyConfig, meterRegistry);
-        this.threadPoolSaturatedCounter = Counter.builder("pubsub.batch.threadpool.saturated")
-                .description("Number of times the batch thread pool rejected tasks due to queue saturation")
-                .register(meterRegistry);
         this.nackCounter = Counter.builder("pubsub.kafka.listener.nacks")
                 .description("Total number of batch nacks")
                 .register(meterRegistry);
@@ -104,7 +100,6 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
                 taskFutureList.add(taskFuture);
             } catch (RejectedExecutionException e) {
                 log.warn("Thread pool queue full, pausing Kafka consumer to apply backpressure at index {}", i);
-                threadPoolSaturatedCounter.increment();
                 rejectedAtIndex = i;
                 break;
             }

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
@@ -11,6 +11,7 @@ import de.telekom.horizon.galaxy.model.PublishedMessageTaskResult;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jetbrains.annotations.NotNull;
@@ -39,14 +40,13 @@ import java.util.concurrent.*;
 public class PublishedMessageListener extends AbstractConsumerSeekAware implements BatchAcknowledgingMessageListener<String, String> {
 
     private final PublishedMessageTaskFactory publishedMessageTaskFactory;
+    @Getter
     private final ThreadPoolTaskExecutor taskExecutor;
     private final HorizonTracer tracer;
     private final GalaxyConfig galaxyConfig;
     private final Counter threadPoolSaturatedCounter;
     private final Counter nackCounter;
-    private final Counter nackDueToRejectionCounter;
     private final Counter nackDueToTaskFailureCounter;
-
 
     public PublishedMessageListener(PublishedMessageTaskFactory publishedMessageTaskFactory, HorizonTracer horizonTracer, GalaxyConfig galaxyConfig, MeterRegistry meterRegistry) {
         super();
@@ -61,9 +61,6 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
         this.nackCounter = Counter.builder("pubsub.kafka.listener.nacks")
                 .description("Total number of batch nacks")
                 .register(meterRegistry);
-        this.nackDueToRejectionCounter = Counter.builder("pubsub.kafka.listener.nacks.rejection")
-                .description("Nacks due to thread pool rejection")
-                .register(meterRegistry);
         this.nackDueToTaskFailureCounter = Counter.builder("pubsub.kafka.listener.nacks.task_failure")
                 .description("Nacks due to task execution failure")
                 .register(meterRegistry);
@@ -75,7 +72,6 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
         threadPoolTaskExecutor.setCorePoolSize(galaxyConfig.getBatchCoreThreadPoolSize());
         threadPoolTaskExecutor.setMaxPoolSize(galaxyConfig.getBatchMaxThreadPoolSize());
         threadPoolTaskExecutor.setQueueCapacity(galaxyConfig.getBatchQueueCapacity());
-        threadPoolTaskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
         threadPoolTaskExecutor.setPrestartAllCoreThreads(true);
         threadPoolTaskExecutor.setThreadGroupName("batch");
         threadPoolTaskExecutor.setThreadNamePrefix("batch-");
@@ -107,7 +103,7 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
                 Future<PublishedMessageTaskResult> taskFuture = taskExecutor.submit(task);
                 taskFutureList.add(taskFuture);
             } catch (RejectedExecutionException e) {
-                log.warn("Thread pool queue full, applying backpressure. Nacking batch from index {}", i);
+                log.warn("Thread pool queue full, pausing Kafka consumer to apply backpressure at index {}", i);
                 threadPoolSaturatedCounter.increment();
                 rejectedAtIndex = i;
                 break;
@@ -142,9 +138,6 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
         } else {
             // Track nack metrics
             nackCounter.increment();
-            if (rejectedAtIndex >= 0) {
-                nackDueToRejectionCounter.increment();
-            }
             if (taskFailureIndex >= 0) {
                 nackDueToTaskFailureCounter.increment();
             }
@@ -175,12 +168,6 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
         }
     }
 
-    /**
-     * Returns a Callable task wrapped with the current trace context obtained from a consumer record.
-     *
-     * @param consumerRecord the consumer record used to create a task
-     * @return a Callable task for processing the received message
-     */
     @SuppressWarnings("unchecked")
     private Callable<PublishedMessageTaskResult> getPublishedMessageTaskResultCallable(ConsumerRecord<String, String> consumerRecord) {
         return (Callable<PublishedMessageTaskResult>) tracer.withCurrentTraceContext(publishedMessageTaskFactory.newTask(consumerRecord));

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
@@ -22,6 +22,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -61,7 +62,6 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
         this.taskExecutor = initThreadPoolTaskExecutor(galaxyConfig, meterRegistry);
         this.threadPoolSaturatedCounter = Counter.builder("galaxy.batch.threadpool.saturated")
                 .description("Number of times the batch thread pool rejected tasks due to queue saturation")
-                .tag("type", "batch")
                 .register(meterRegistry);
         this.nackCounter = Counter.builder("galaxy.kafka.listener.nacks")
                 .description("Total number of batch nacks")
@@ -88,7 +88,7 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
         
         // Register metrics for the thread pool
         ExecutorServiceMetrics.monitor(meterRegistry, threadPoolTaskExecutor.getThreadPoolExecutor(), 
-            "galaxy.batch.threadpool", Tag.of("type", "batch"));
+            "batchTaskExecutor", Collections.emptyList());
         
         return threadPoolTaskExecutor;
     }
@@ -128,9 +128,12 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
                     taskFailureIndex = index;
                 }
             } catch (ExecutionException | InterruptedException e) {
-                log.error("Unexpected error processing event task", e);
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
+                log.error("Unexpected error processing event task at index {}", index, e);
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                taskFailureIndex = index;
+                break;
             }
         }
 

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
@@ -10,7 +10,6 @@ import de.telekom.horizon.galaxy.config.GalaxyConfig;
 import de.telekom.horizon.galaxy.model.PublishedMessageTaskResult;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -24,11 +23,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.*;
 
 /**
  * The {@code PublishedMessageListener} class is responsible for processing Kafka messages in batches.
@@ -60,16 +55,16 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
         this.galaxyConfig = galaxyConfig;
 
         this.taskExecutor = initThreadPoolTaskExecutor(galaxyConfig, meterRegistry);
-        this.threadPoolSaturatedCounter = Counter.builder("galaxy.batch.threadpool.saturated")
+        this.threadPoolSaturatedCounter = Counter.builder("pubsub.batch.threadpool.saturated")
                 .description("Number of times the batch thread pool rejected tasks due to queue saturation")
                 .register(meterRegistry);
-        this.nackCounter = Counter.builder("galaxy.kafka.listener.nacks")
+        this.nackCounter = Counter.builder("pubsub.kafka.listener.nacks")
                 .description("Total number of batch nacks")
                 .register(meterRegistry);
-        this.nackDueToRejectionCounter = Counter.builder("galaxy.kafka.listener.nacks.rejection")
+        this.nackDueToRejectionCounter = Counter.builder("pubsub.kafka.listener.nacks.rejection")
                 .description("Nacks due to thread pool rejection")
                 .register(meterRegistry);
-        this.nackDueToTaskFailureCounter = Counter.builder("galaxy.kafka.listener.nacks.task_failure")
+        this.nackDueToTaskFailureCounter = Counter.builder("pubsub.kafka.listener.nacks.task_failure")
                 .description("Nacks due to task execution failure")
                 .register(meterRegistry);
     }
@@ -132,7 +127,9 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                 }
-                taskFailureIndex = index;
+                if (taskFailureIndex == -1) {
+                    taskFailureIndex = index;
+                }
                 break;
             }
         }

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListener.java
@@ -8,6 +8,10 @@ import de.telekom.eni.pandora.horizon.model.event.PublishedEventMessage;
 import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
 import de.telekom.horizon.galaxy.config.GalaxyConfig;
 import de.telekom.horizon.galaxy.model.PublishedMessageTaskResult;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jetbrains.annotations.NotNull;
@@ -22,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -40,26 +45,51 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
     private final PublishedMessageTaskFactory publishedMessageTaskFactory;
     private final ThreadPoolTaskExecutor taskExecutor;
     private final HorizonTracer tracer;
+    private final GalaxyConfig galaxyConfig;
+    private final Counter threadPoolSaturatedCounter;
+    private final Counter nackCounter;
+    private final Counter nackDueToRejectionCounter;
+    private final Counter nackDueToTaskFailureCounter;
 
 
-    public PublishedMessageListener(PublishedMessageTaskFactory publishedMessageTaskFactory, HorizonTracer horizonTracer, GalaxyConfig galaxyConfig) {
+    public PublishedMessageListener(PublishedMessageTaskFactory publishedMessageTaskFactory, HorizonTracer horizonTracer, GalaxyConfig galaxyConfig, MeterRegistry meterRegistry) {
         super();
         this.publishedMessageTaskFactory = publishedMessageTaskFactory;
         this.tracer = horizonTracer;
+        this.galaxyConfig = galaxyConfig;
 
-        this.taskExecutor = initThreadPoolTaskExecutor(galaxyConfig);
+        this.taskExecutor = initThreadPoolTaskExecutor(galaxyConfig, meterRegistry);
+        this.threadPoolSaturatedCounter = Counter.builder("galaxy.batch.threadpool.saturated")
+                .description("Number of times the batch thread pool rejected tasks due to queue saturation")
+                .tag("type", "batch")
+                .register(meterRegistry);
+        this.nackCounter = Counter.builder("galaxy.kafka.listener.nacks")
+                .description("Total number of batch nacks")
+                .register(meterRegistry);
+        this.nackDueToRejectionCounter = Counter.builder("galaxy.kafka.listener.nacks.rejection")
+                .description("Nacks due to thread pool rejection")
+                .register(meterRegistry);
+        this.nackDueToTaskFailureCounter = Counter.builder("galaxy.kafka.listener.nacks.task_failure")
+                .description("Nacks due to task execution failure")
+                .register(meterRegistry);
     }
 
     @NotNull
-    private ThreadPoolTaskExecutor initThreadPoolTaskExecutor(GalaxyConfig galaxyConfig) {
+    private ThreadPoolTaskExecutor initThreadPoolTaskExecutor(GalaxyConfig galaxyConfig, MeterRegistry meterRegistry) {
         final ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(galaxyConfig.getBatchCoreThreadPoolSize());
         threadPoolTaskExecutor.setMaxPoolSize(galaxyConfig.getBatchMaxThreadPoolSize());
-        threadPoolTaskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        threadPoolTaskExecutor.setQueueCapacity(galaxyConfig.getBatchQueueCapacity());
+        threadPoolTaskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
         threadPoolTaskExecutor.setPrestartAllCoreThreads(true);
         threadPoolTaskExecutor.setThreadGroupName("batch");
-        threadPoolTaskExecutor.setThreadNamePrefix("batch");
+        threadPoolTaskExecutor.setThreadNamePrefix("batch-");
         threadPoolTaskExecutor.afterPropertiesSet();
+        
+        // Register metrics for the thread pool
+        ExecutorServiceMetrics.monitor(meterRegistry, threadPoolTaskExecutor.getThreadPoolExecutor(), 
+            "galaxy.batch.threadpool", Tag.of("type", "batch"));
+        
         return threadPoolTaskExecutor;
     }
 
@@ -72,19 +102,30 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
     @Override
     public void onMessage(List<ConsumerRecord<String, String>> consumerRecords, @NotNull Acknowledgment acknowledgment) {
         List<Future<PublishedMessageTaskResult>> taskFutureList = new ArrayList<>();
+        int rejectedAtIndex = -1;
 
-        for (ConsumerRecord<String, String> consumerRecord: consumerRecords) {
+        // Submit tasks until rejection or all submitted
+        for (int i = 0; i < consumerRecords.size(); i++) {
+            var consumerRecord = consumerRecords.get(i);
             var task = getPublishedMessageTaskResultCallable(consumerRecord);
-            Future<PublishedMessageTaskResult> taskFuture = taskExecutor.submit(task);
-            taskFutureList.add(taskFuture);
+            try {
+                Future<PublishedMessageTaskResult> taskFuture = taskExecutor.submit(task);
+                taskFutureList.add(taskFuture);
+            } catch (RejectedExecutionException e) {
+                log.warn("Thread pool queue full, applying backpressure. Nacking batch from index {}", i);
+                threadPoolSaturatedCounter.increment();
+                rejectedAtIndex = i;
+                break;
+            }
         }
 
-        var nackIndex = -1;
+        // Wait for all submitted tasks to complete and check for failures
+        var taskFailureIndex = -1;
         for (int index = 0; index < taskFutureList.size(); index++) {
             try {
                 var taskResult = taskFutureList.get(index).get();
-                if (!taskResult.isSuccessful() && nackIndex == -1) {
-                    nackIndex = index;
+                if (!taskResult.isSuccessful() && taskFailureIndex == -1) {
+                    taskFailureIndex = index;
                 }
             } catch (ExecutionException | InterruptedException e) {
                 log.error("Unexpected error processing event task", e);
@@ -93,13 +134,45 @@ public class PublishedMessageListener extends AbstractConsumerSeekAware implemen
             }
         }
 
-        //If a nackIndex has been set during the processing of the futures, a nack will be sent to Kafka
-        if (nackIndex < 0) {
+        // Determine the earliest failure point (rejection or task failure)
+        int finalNackIndex = determineNackIndex(rejectedAtIndex, taskFailureIndex);
+
+        if (finalNackIndex < 0) {
             acknowledgment.acknowledge();
         } else {
-            acknowledgment.nack(nackIndex, Duration.ofMillis(5000));
+            // Track nack metrics
+            nackCounter.increment();
+            if (rejectedAtIndex >= 0) {
+                nackDueToRejectionCounter.increment();
+            }
+            if (taskFailureIndex >= 0) {
+                nackDueToTaskFailureCounter.increment();
+            }
+            acknowledgment.nack(finalNackIndex, Duration.ofMillis(galaxyConfig.getNackSleepDurationMs()));
         }
 
+    }
+
+    /**
+     * Determines the final nack index by taking the minimum of rejection and task failure indices.
+     * This ensures we nack from the earliest failure point, whether it's due to thread pool saturation
+     * or task execution failure.
+     *
+     * @param rejectedAtIndex  Index where thread pool rejected task submission (-1 if no rejection)
+     * @param taskFailureIndex Index where a submitted task failed (-1 if no task failure)
+     * @return The minimum valid index, or -1 if both are -1 (success)
+     */
+    private int determineNackIndex(int rejectedAtIndex, int taskFailureIndex) {
+        if (rejectedAtIndex >= 0 && taskFailureIndex >= 0) {
+            // Both failures occurred - use the earlier one
+            return Math.min(rejectedAtIndex, taskFailureIndex);
+        } else if (rejectedAtIndex >= 0) {
+            // Only rejection occurred
+            return rejectedAtIndex;
+        } else {
+            // Only task failure occurred (or no failure at all)
+            return taskFailureIndex;
+        }
     }
 
     /**

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -38,6 +38,7 @@ import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
@@ -64,11 +65,13 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
     private final PayloadSizeHistogramCache incomingPayloadSizeCache;
     private final PayloadSizeHistogramCache outgoingPayloadSizeHistogramCache;
     private final GalaxyConfig galaxyConfig;
+    private final PublishedMessageTaskFactory factory;
 
     private final ThreadPoolTaskExecutor taskExecutor;
 
     public PublishedMessageTask(ConsumerRecord<String, String> consumerRecord, PublishedMessageTaskFactory factory) {
         this.consumerRecord = consumerRecord;
+        this.factory = factory;
 
         this.tracer = factory.getTracer();
         this.eventWriter = factory.getEventWriter();
@@ -79,20 +82,7 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
         this.outgoingPayloadSizeHistogramCache = factory.getOutgoingPayloadSizeHistogramCache();
         this.objectMapper = factory.getObjectMapper();
         this.galaxyConfig = factory.getGalaxyConfig();
-
-        taskExecutor = initThreadPoolTaskExecutor(factory);
-    }
-
-    @NotNull
-    private ThreadPoolTaskExecutor initThreadPoolTaskExecutor(PublishedMessageTaskFactory factory) {
-        final ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
-        threadPoolTaskExecutor.setThreadGroupName("multiplex");
-        threadPoolTaskExecutor.setThreadNamePrefix("multiplex");
-        threadPoolTaskExecutor.setCorePoolSize(factory.getGalaxyConfig().getSubscriptionCoreThreadPoolSize());
-        threadPoolTaskExecutor.setMaxPoolSize(factory.getGalaxyConfig().getSubscriptionMaxThreadPoolSize());
-        threadPoolTaskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
-        threadPoolTaskExecutor.afterPropertiesSet();
-        return threadPoolTaskExecutor;
+        this.taskExecutor = factory.getSubscriptionTaskExecutor();
     }
 
     @Override
@@ -145,7 +135,8 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
 
             return new PublishedMessageTaskResult(isSuccessful.get());
         } finally {
-            shutdownTaskExecutorAndFinishSpan(span);
+            MDC.clear();
+            span.finish();
         }
     }
 
@@ -188,17 +179,6 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
     }
 
     /**
-     * Shuts down the task executor and finishes the given span.
-     *
-     * @param span The span to finish.
-     */
-    private void shutdownTaskExecutorAndFinishSpan(Span span) {
-        taskExecutor.shutdown();
-        MDC.clear();
-        span.finish();
-    }
-
-    /**
      * Sends either an {@link SubscriptionEventMessage} or an ({@link Status#FAILED}|{@link Status#DROPPED} {@link StatusMessage} in a new Task to Kafka for the given {@link SubscriptionEventMessage}.
      *
      * @param subscriptionEventMessage             The SubscriptionEventMessage to send.
@@ -208,7 +188,8 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
     @NotNull
     private CompletableFuture<Void> sendMessageToKafkaAsync(SubscriptionEventMessage subscriptionEventMessage, Map<String, FilterEventMessageWrapper> filteredEventMessagesPerRecipient) {
         var mdcMap = MDC.getCopyOfContextMap();
-        return CompletableFuture.runAsync(tracer.withCurrentTraceContext(() -> {
+        try {
+            return CompletableFuture.runAsync(tracer.withCurrentTraceContext(() -> {
             MDC.setContextMap(mdcMap);
             var multiplexSpan = tracer.startScopedSpan("multiplex message");
 
@@ -234,6 +215,14 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
                 MDC.clear();
             }
         }), taskExecutor);
+        } catch (RejectedExecutionException e) {
+            log.warn("Subscription thread pool queue full for subscription {}", subscriptionEventMessage.getSubscriptionId());
+            factory.incrementSubscriptionThreadPoolSaturatedCounter();
+            // Return a failed future to maintain error handling flow
+            CompletableFuture<Void> failedFuture = new CompletableFuture<>();
+            failedFuture.completeExceptionally(e);
+            return failedFuture;
+        }
     }
 
     /**

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -216,9 +216,7 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
         } catch (RejectedExecutionException e) {
             log.warn("Subscription thread pool queue full for subscription {}", subscriptionEventMessage.getSubscriptionId());
             // Return a failed future to maintain error handling flow
-            CompletableFuture<Void> failedFuture = new CompletableFuture<>();
-            failedFuture.completeExceptionally(e);
-            return failedFuture;
+            return CompletableFuture.failedFuture(e);
         }
     }
 

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -5,7 +5,6 @@
 package de.telekom.horizon.galaxy.kafka;
 
 import brave.ScopedSpan;
-import brave.Span;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,10 +23,10 @@ import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
 import de.telekom.horizon.galaxy.cache.PayloadSizeHistogramCache;
 import de.telekom.horizon.galaxy.cache.SubscriberCache;
 import de.telekom.horizon.galaxy.config.GalaxyConfig;
-import de.telekom.horizon.galaxy.model.EvaluationResultStatus;
-import de.telekom.horizon.galaxy.model.PublishedMessageTaskResult;
 import de.telekom.horizon.galaxy.filters.FilterEventMessageWrapper;
 import de.telekom.horizon.galaxy.filters.Filters;
+import de.telekom.horizon.galaxy.model.EvaluationResultStatus;
+import de.telekom.horizon.galaxy.model.PublishedMessageTaskResult;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jetbrains.annotations.NotNull;
@@ -39,7 +38,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -96,6 +96,8 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
             } catch (JsonProcessingException e) {
                 log.error("JsonProcessingException occurred while parsing published event message with key {}!", consumerRecord.key(), e);
 
+                // Better to move to DLQ for messages that are not parseable
+
                 return new PublishedMessageTaskResult(true);
             }
 
@@ -135,8 +137,8 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
 
             return new PublishedMessageTaskResult(isSuccessful.get());
         } finally {
-            MDC.clear();
-            span.finish();
+          span.finish();
+          MDC.clear();
         }
     }
 

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTask.java
@@ -63,13 +63,11 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
     private final PayloadSizeHistogramCache incomingPayloadSizeCache;
     private final PayloadSizeHistogramCache outgoingPayloadSizeHistogramCache;
     private final GalaxyConfig galaxyConfig;
-    private final PublishedMessageTaskFactory factory;
 
     private final ThreadPoolTaskExecutor taskExecutor;
 
     public PublishedMessageTask(ConsumerRecord<String, String> consumerRecord, PublishedMessageTaskFactory factory) {
         this.consumerRecord = consumerRecord;
-        this.factory = factory;
 
         this.tracer = factory.getTracer();
         this.eventWriter = factory.getEventWriter();
@@ -217,7 +215,6 @@ public class PublishedMessageTask implements Callable<PublishedMessageTaskResult
         }), taskExecutor);
         } catch (RejectedExecutionException e) {
             log.warn("Subscription thread pool queue full for subscription {}", subscriptionEventMessage.getSubscriptionId());
-            factory.incrementSubscriptionThreadPoolSaturatedCounter();
             // Return a failed future to maintain error handling flow
             CompletableFuture<Void> failedFuture = new CompletableFuture<>();
             failedFuture.completeExceptionally(e);

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
@@ -25,7 +25,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
-import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Factory for creating tasks associated with a published message.
@@ -76,7 +75,6 @@ public class PublishedMessageTaskFactory {
         threadPoolTaskExecutor.setCorePoolSize(galaxyConfig.getSubscriptionCoreThreadPoolSize());
         threadPoolTaskExecutor.setMaxPoolSize(galaxyConfig.getSubscriptionMaxThreadPoolSize());
         threadPoolTaskExecutor.setQueueCapacity(galaxyConfig.getSubscriptionQueueCapacity());
-        threadPoolTaskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
         threadPoolTaskExecutor.setPrestartAllCoreThreads(true);
         threadPoolTaskExecutor.afterPropertiesSet();
         

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
@@ -16,7 +16,6 @@ import de.telekom.horizon.galaxy.cache.SubscriberCache;
 import de.telekom.horizon.galaxy.config.GalaxyConfig;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import lombok.Getter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -26,7 +25,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -66,7 +64,7 @@ public class PublishedMessageTaskFactory {
         this.objectMapper = objectMapper;
         this.meterRegistry = meterRegistry;
         this.subscriptionTaskExecutor = initSubscriptionThreadPoolTaskExecutor();
-        this.subscriptionThreadPoolSaturatedCounter = Counter.builder("galaxy.subscription.threadpool.saturated")
+        this.subscriptionThreadPoolSaturatedCounter = Counter.builder("pubsub.subscription.threadpool.saturated")
                 .description("Number of times the subscription thread pool rejected tasks due to queue saturation")
                 .register(meterRegistry);
     }

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
@@ -14,7 +14,6 @@ import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
 import de.telekom.horizon.galaxy.cache.PayloadSizeHistogramCache;
 import de.telekom.horizon.galaxy.cache.SubscriberCache;
 import de.telekom.horizon.galaxy.config.GalaxyConfig;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import lombok.Getter;
@@ -47,7 +46,6 @@ public class PublishedMessageTaskFactory {
     private final ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
     private final ThreadPoolTaskExecutor subscriptionTaskExecutor;
-    private final Counter subscriptionThreadPoolSaturatedCounter;
 
     @Autowired
     public PublishedMessageTaskFactory(HorizonTracer tracer, EventWriter eventWriter, HorizonMetricsHelper metricsHelper, SubscriberCache subscriptionCache, DeDuplicationService deDuplicationService, KafkaProperties kafkaProperties, @Qualifier("incomingPayloadSizeCache") PayloadSizeHistogramCache incomingPayloadSizeCache, @Qualifier("outgoingPayloadSizeCache") PayloadSizeHistogramCache outgoingPayloadSizeHistogramCache, GalaxyConfig galaxyConfig, ObjectMapper objectMapper, MeterRegistry meterRegistry) {
@@ -63,9 +61,6 @@ public class PublishedMessageTaskFactory {
         this.objectMapper = objectMapper;
         this.meterRegistry = meterRegistry;
         this.subscriptionTaskExecutor = initSubscriptionThreadPoolTaskExecutor();
-        this.subscriptionThreadPoolSaturatedCounter = Counter.builder("pubsub.subscription.threadpool.saturated")
-                .description("Number of times the subscription thread pool rejected tasks due to queue saturation")
-                .register(meterRegistry);
     }
 
     private ThreadPoolTaskExecutor initSubscriptionThreadPoolTaskExecutor() {
@@ -87,9 +82,5 @@ public class PublishedMessageTaskFactory {
 
     public PublishedMessageTask newTask(ConsumerRecord<String, String> consumerRecord) {
         return new PublishedMessageTask(consumerRecord, this);
-    }
-
-    public void incrementSubscriptionThreadPoolSaturatedCounter() {
-        subscriptionThreadPoolSaturatedCounter.increment();
     }
 }

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
@@ -14,11 +14,19 @@ import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
 import de.telekom.horizon.galaxy.cache.PayloadSizeHistogramCache;
 import de.telekom.horizon.galaxy.cache.SubscriberCache;
 import de.telekom.horizon.galaxy.config.GalaxyConfig;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import lombok.Getter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Factory for creating tasks associated with a published message.
@@ -39,9 +47,12 @@ public class PublishedMessageTaskFactory {
     private final PayloadSizeHistogramCache outgoingPayloadSizeHistogramCache;
     private final GalaxyConfig galaxyConfig;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
+    private final ThreadPoolTaskExecutor subscriptionTaskExecutor;
+    private final Counter subscriptionThreadPoolSaturatedCounter;
 
     @Autowired
-    public PublishedMessageTaskFactory(HorizonTracer tracer, EventWriter eventWriter, HorizonMetricsHelper metricsHelper, SubscriberCache subscriptionCache, DeDuplicationService deDuplicationService, KafkaProperties kafkaProperties, @Qualifier("incomingPayloadSizeCache") PayloadSizeHistogramCache incomingPayloadSizeCache, @Qualifier("outgoingPayloadSizeCache") PayloadSizeHistogramCache outgoingPayloadSizeHistogramCache, GalaxyConfig galaxyConfig, ObjectMapper objectMapper) {
+    public PublishedMessageTaskFactory(HorizonTracer tracer, EventWriter eventWriter, HorizonMetricsHelper metricsHelper, SubscriberCache subscriptionCache, DeDuplicationService deDuplicationService, KafkaProperties kafkaProperties, @Qualifier("incomingPayloadSizeCache") PayloadSizeHistogramCache incomingPayloadSizeCache, @Qualifier("outgoingPayloadSizeCache") PayloadSizeHistogramCache outgoingPayloadSizeHistogramCache, GalaxyConfig galaxyConfig, ObjectMapper objectMapper, MeterRegistry meterRegistry) {
         this.tracer = tracer;
         this.eventWriter = eventWriter;
         this.metricsHelper = metricsHelper;
@@ -52,9 +63,37 @@ public class PublishedMessageTaskFactory {
         this.outgoingPayloadSizeHistogramCache = outgoingPayloadSizeHistogramCache;
         this.galaxyConfig = galaxyConfig;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
+        this.subscriptionTaskExecutor = initSubscriptionThreadPoolTaskExecutor();
+        this.subscriptionThreadPoolSaturatedCounter = Counter.builder("galaxy.subscription.threadpool.saturated")
+                .description("Number of times the subscription thread pool rejected tasks due to queue saturation")
+                .tag("type", "multiplex")
+                .register(meterRegistry);
+    }
+
+    private ThreadPoolTaskExecutor initSubscriptionThreadPoolTaskExecutor() {
+        final ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+        threadPoolTaskExecutor.setThreadGroupName("multiplex");
+        threadPoolTaskExecutor.setThreadNamePrefix("multiplex-");
+        threadPoolTaskExecutor.setCorePoolSize(galaxyConfig.getSubscriptionCoreThreadPoolSize());
+        threadPoolTaskExecutor.setMaxPoolSize(galaxyConfig.getSubscriptionMaxThreadPoolSize());
+        threadPoolTaskExecutor.setQueueCapacity(galaxyConfig.getSubscriptionQueueCapacity());
+        threadPoolTaskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        threadPoolTaskExecutor.setPrestartAllCoreThreads(true);
+        threadPoolTaskExecutor.afterPropertiesSet();
+        
+        // Register metrics for the thread pool
+        ExecutorServiceMetrics.monitor(meterRegistry, threadPoolTaskExecutor.getThreadPoolExecutor(), 
+            "galaxy.subscription.threadpool", Tag.of("type", "multiplex"));
+        
+        return threadPoolTaskExecutor;
     }
 
     public PublishedMessageTask newTask(ConsumerRecord<String, String> consumerRecord) {
         return new PublishedMessageTask(consumerRecord, this);
+    }
+
+    public void incrementSubscriptionThreadPoolSaturatedCounter() {
+        subscriptionThreadPoolSaturatedCounter.increment();
     }
 }

--- a/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
+++ b/src/main/java/de/telekom/horizon/galaxy/kafka/PublishedMessageTaskFactory.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -67,7 +68,6 @@ public class PublishedMessageTaskFactory {
         this.subscriptionTaskExecutor = initSubscriptionThreadPoolTaskExecutor();
         this.subscriptionThreadPoolSaturatedCounter = Counter.builder("galaxy.subscription.threadpool.saturated")
                 .description("Number of times the subscription thread pool rejected tasks due to queue saturation")
-                .tag("type", "multiplex")
                 .register(meterRegistry);
     }
 
@@ -84,7 +84,7 @@ public class PublishedMessageTaskFactory {
         
         // Register metrics for the thread pool
         ExecutorServiceMetrics.monitor(meterRegistry, threadPoolTaskExecutor.getThreadPoolExecutor(), 
-            "galaxy.subscription.threadpool", Tag.of("type", "multiplex"));
+            "subscriptionTaskExecutor", Collections.emptyList());
         
         return threadPoolTaskExecutor;
     }

--- a/src/main/java/de/telekom/horizon/galaxy/service/BackpressureHandler.java
+++ b/src/main/java/de/telekom/horizon/galaxy/service/BackpressureHandler.java
@@ -104,7 +104,7 @@ public class BackpressureHandler implements RejectedExecutionHandler {
      * Periodically checks whether both thread pools have recovered enough capacity
      * and resumes the Kafka listener container if it was previously paused.
      */
-    @Scheduled(fixedDelayString = "${galaxy.backpressure-resume-check-interval-ms:1000}")
+    @Scheduled(fixedDelayString = "${galaxy.backpressure-resume-check-interval-ms}")
     public void checkAndResume() {
         if (!isPaused()) {
             return;

--- a/src/main/java/de/telekom/horizon/galaxy/service/BackpressureHandler.java
+++ b/src/main/java/de/telekom/horizon/galaxy/service/BackpressureHandler.java
@@ -5,10 +5,11 @@
 package de.telekom.horizon.galaxy.service;
 
 import de.telekom.horizon.galaxy.config.GalaxyConfig;
+import de.telekom.horizon.galaxy.kafka.PublishedMessageListener;
+import de.telekom.horizon.galaxy.kafka.PublishedMessageTaskFactory;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -29,9 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <p>
  * Periodically checks whether both the batch and subscription thread pools have recovered
  * enough capacity and resumes the Kafka listener container if it was previously paused.
- * <p>
- * The container reference is set after construction via {@link #setListenerContainer} from the
- * {@link de.telekom.horizon.galaxy.config.kafka.KafkaConsumerConfig}.
  */
 @Component
 @Slf4j
@@ -41,17 +39,21 @@ public class BackpressureHandler implements RejectedExecutionHandler {
     private final Counter pauseCounter;
     private final GalaxyConfig galaxyConfig;
 
-    @Setter
-    private volatile ConcurrentMessageListenerContainer<String, String> listenerContainer;
+    private final ConcurrentMessageListenerContainer<String, String> listenerContainer;
+    private final ThreadPoolTaskExecutor batchExecutor;
+    private final ThreadPoolTaskExecutor subscriptionExecutor;
 
-    @Setter
-    private volatile ThreadPoolTaskExecutor batchExecutor;
-
-    @Setter
-    private volatile ThreadPoolTaskExecutor subscriptionExecutor;
-
-    public BackpressureHandler(MeterRegistry meterRegistry, GalaxyConfig galaxyConfig) {
+    public BackpressureHandler(MeterRegistry meterRegistry, GalaxyConfig galaxyConfig, ConcurrentMessageListenerContainer<String, String> listenerContainer,
+                               PublishedMessageTaskFactory publishedMessageTaskFactory, PublishedMessageListener publishedMessageListener) {
         this.galaxyConfig = galaxyConfig;
+
+        this.listenerContainer = listenerContainer;
+        this.batchExecutor = publishedMessageListener.getTaskExecutor();
+        this.subscriptionExecutor = publishedMessageTaskFactory.getSubscriptionTaskExecutor();
+
+        publishedMessageListener.getTaskExecutor().getThreadPoolExecutor().setRejectedExecutionHandler(this);
+        publishedMessageTaskFactory.getSubscriptionTaskExecutor().getThreadPoolExecutor().setRejectedExecutionHandler(this);
+
         this.pauseCounter = Counter.builder("pubsub.kafka.listener.pause.triggered")
                 .description("Number of times the Kafka listener was paused due to backpressure")
                 .register(meterRegistry);
@@ -71,12 +73,12 @@ public class BackpressureHandler implements RejectedExecutionHandler {
         throw new RejectedExecutionException("Task " + r.toString() + " rejected from " + executor.toString());
     }
 
-  /**
+    /**
      * Pauses the Kafka listener container to stop consuming new records.
      * Safe to call from any thread; only the first call while unpaused takes effect.
      */
     public void pause() {
-        if (listenerContainer != null && !paused.getAndSet(true)) {
+        if (!paused.getAndSet(true)) {
             listenerContainer.pause();
             pauseCounter.increment();
             log.info("Kafka listener container paused due to thread pool saturation.");
@@ -88,7 +90,7 @@ public class BackpressureHandler implements RejectedExecutionHandler {
      * Safe to call from any thread; only the first call while paused takes effect.
      */
     public void resume() {
-        if (listenerContainer != null && paused.getAndSet(false)) {
+        if (paused.getAndSet(false)) {
             listenerContainer.resume();
             log.info("Kafka listener container resumed after thread pool capacity recovered.");
         }
@@ -123,9 +125,6 @@ public class BackpressureHandler implements RejectedExecutionHandler {
     }
 
     private double getQueueUsageRatio(ThreadPoolTaskExecutor executor) {
-        if (executor == null) {
-            return 0.0;
-        }
         var queue = executor.getThreadPoolExecutor().getQueue();
         int totalCapacity = queue.size() + queue.remainingCapacity();
         return totalCapacity > 0 ? (double) queue.size() / totalCapacity : 0.0;

--- a/src/main/java/de/telekom/horizon/galaxy/service/BackpressureHandler.java
+++ b/src/main/java/de/telekom/horizon/galaxy/service/BackpressureHandler.java
@@ -1,0 +1,133 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.galaxy.service;
+
+import de.telekom.horizon.galaxy.config.GalaxyConfig;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Centralized handler for Kafka consumer backpressure.
+ * <p>
+ * Implements {@link RejectedExecutionHandler} so it can be registered directly on thread pool executors.
+ * When a task is rejected, {@link #rejectedExecution} automatically pauses the Kafka consumer,
+ * removing the need for callers to explicitly invoke {@link #pause()}.
+ * <p>
+ * Periodically checks whether both the batch and subscription thread pools have recovered
+ * enough capacity and resumes the Kafka listener container if it was previously paused.
+ * <p>
+ * The container reference is set after construction via {@link #setListenerContainer} from the
+ * {@link de.telekom.horizon.galaxy.config.kafka.KafkaConsumerConfig}.
+ */
+@Component
+@Slf4j
+public class BackpressureHandler implements RejectedExecutionHandler {
+
+    private final AtomicBoolean paused = new AtomicBoolean(false);
+    private final Counter pauseCounter;
+    private final GalaxyConfig galaxyConfig;
+
+    @Setter
+    private volatile ConcurrentMessageListenerContainer<String, String> listenerContainer;
+
+    @Setter
+    private volatile ThreadPoolTaskExecutor batchExecutor;
+
+    @Setter
+    private volatile ThreadPoolTaskExecutor subscriptionExecutor;
+
+    public BackpressureHandler(MeterRegistry meterRegistry, GalaxyConfig galaxyConfig) {
+        this.galaxyConfig = galaxyConfig;
+        this.pauseCounter = Counter.builder("pubsub.kafka.listener.pause.triggered")
+                .description("Number of times the Kafka listener was paused due to backpressure")
+                .register(meterRegistry);
+        Gauge.builder("pubsub.kafka.listener.paused", paused, p -> p.get() ? 1.0 : 0.0)
+                .description("Whether the Kafka listener is currently paused due to backpressure")
+                .register(meterRegistry);
+    }
+
+    /**
+     * Called by the JVM when a thread pool rejects a task submission.
+     * Pauses the Kafka listener container and re-throws the rejection as a
+     * {@link RejectedExecutionException} so the caller can handle it.
+     */
+    @Override
+    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+        pause();
+        throw new RejectedExecutionException("Task " + r.toString() + " rejected from " + executor.toString());
+    }
+
+  /**
+     * Pauses the Kafka listener container to stop consuming new records.
+     * Safe to call from any thread; only the first call while unpaused takes effect.
+     */
+    public void pause() {
+        if (listenerContainer != null && !paused.getAndSet(true)) {
+            listenerContainer.pause();
+            pauseCounter.increment();
+            log.info("Kafka listener container paused due to thread pool saturation.");
+        }
+    }
+
+    /**
+     * Resumes the Kafka listener container to continue consuming records.
+     * Safe to call from any thread; only the first call while paused takes effect.
+     */
+    public void resume() {
+        if (listenerContainer != null && paused.getAndSet(false)) {
+            listenerContainer.resume();
+            log.info("Kafka listener container resumed after thread pool capacity recovered.");
+        }
+    }
+
+    public boolean isPaused() {
+        return paused.get();
+    }
+
+    /**
+     * Periodically checks whether both thread pools have recovered enough capacity
+     * and resumes the Kafka listener container if it was previously paused.
+     */
+    @Scheduled(fixedDelayString = "${galaxy.backpressure-resume-check-interval-ms:1000}")
+    public void checkAndResume() {
+        if (!isPaused()) {
+            return;
+        }
+
+        double batchUsage = getQueueUsageRatio(batchExecutor);
+        double subscriptionUsage = getQueueUsageRatio(subscriptionExecutor);
+        double threshold = galaxyConfig.getBackpressureResumeThreshold();
+
+        if (batchUsage <= threshold && subscriptionUsage <= threshold) {
+            log.info("Both thread pool queues below resume threshold ({}). Batch: {}, Subscription: {}. Resuming Kafka consumer.",
+                    threshold, String.format("%.2f", batchUsage), String.format("%.2f", subscriptionUsage));
+            resume();
+        } else {
+            log.debug("Thread pool queues still above resume threshold ({}). Batch: {}, Subscription: {}.",
+                    threshold, String.format("%.2f", batchUsage), String.format("%.2f", subscriptionUsage));
+        }
+    }
+
+    private double getQueueUsageRatio(ThreadPoolTaskExecutor executor) {
+        if (executor == null) {
+            return 0.0;
+        }
+        var queue = executor.getThreadPoolExecutor().getQueue();
+        int totalCapacity = queue.size() + queue.remainingCapacity();
+        return totalCapacity > 0 ? (double) queue.size() / totalCapacity : 0.0;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ galaxy:
   subscription-max-threadpool-size: ${GALAXY_SUBSCRIPTION_MAX_THREADPOOL_SIZE:50}
   subscription-queue-capacity: ${GALAXY_SUBSCRIPTION_QUEUE_CAPACITY:15000}
   nack-sleep-duration-ms: ${GALAXY_NACK_SLEEP_DURATION_MS:5000}
-  backpressure-resume-check-interval-ms: ${GALAXY_BACKPRESSURE_RESUME_CHECK_INTERVAL_MS:1000}
+  backpressure-resume-check-interval-ms: 5000
   backpressure-resume-threshold: ${GALAXY_BACKPRESSURE_RESUME_THRESHOLD:0.5}
   default-environment: ${GALAXY_DEFAULT_ENVIRONMENT:default}
   feature-jsonpath-filtering-enabled: ${GALAXY_FEATURE_JSONPATH_FILTERING_ENABLED:false}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,10 +49,10 @@ pandora:
     name: horizon
 
 galaxy:
-  batch-core-threadpool-size: ${GALAXY_CORE_THREADPOOL_SIZE:10}
+  batch-core-threadpool-size: ${GALAXY_CORE_THREADPOOL_SIZE:40}
   batch-max-threadpool-size: ${GALAXY_MAX_THREADPOOL_SIZE:40}
   batch-queue-capacity: ${GALAXY_BATCH_QUEUE_CAPACITY:1400}
-  subscription-core-threadpool-size: ${GALAXY_SUBSCRIPTION_CORE_THREADPOOL_SIZE:20}
+  subscription-core-threadpool-size: ${GALAXY_SUBSCRIPTION_CORE_THREADPOOL_SIZE:50}
   subscription-max-threadpool-size: ${GALAXY_SUBSCRIPTION_MAX_THREADPOOL_SIZE:50}
   subscription-queue-capacity: ${GALAXY_SUBSCRIPTION_QUEUE_CAPACITY:15000}
   nack-sleep-duration-ms: ${GALAXY_NACK_SLEEP_DURATION_MS:5000}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,8 +77,6 @@ management:
   endpoint:
     health:
       show-details: always
-    shutdown:
-      enabled: true
   health:
     hazelcast:
       enabled: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,10 +49,13 @@ pandora:
     name: horizon
 
 galaxy:
-  batch-core-threadpool-size: ${GALAXY_CORE_THREADPOOL_SIZE:5}
-  batch-max-threadpool-size: ${GALAXY_MAX_THREADPOOL_SIZE:100}
-  subscription-core-threadpool-size: ${GALAXY_SUBSCRIPTION_CORE_THREADPOOL_SIZE:10}
-  subscription-max-threadpool-size: ${GALAXY_SUBSCRIPTION_MAX_THREADPOOL_SIZE:20}
+  batch-core-threadpool-size: ${GALAXY_CORE_THREADPOOL_SIZE:10}
+  batch-max-threadpool-size: ${GALAXY_MAX_THREADPOOL_SIZE:50}
+  batch-queue-capacity: ${GALAXY_BATCH_QUEUE_CAPACITY:100}
+  subscription-core-threadpool-size: ${GALAXY_SUBSCRIPTION_CORE_THREADPOOL_SIZE:20}
+  subscription-max-threadpool-size: ${GALAXY_SUBSCRIPTION_MAX_THREADPOOL_SIZE:50}
+  subscription-queue-capacity: ${GALAXY_SUBSCRIPTION_QUEUE_CAPACITY:200}
+  nack-sleep-duration-ms: ${GALAXY_NACK_SLEEP_DURATION_MS:5000}
   default-environment: ${GALAXY_DEFAULT_ENVIRONMENT:default}
   feature-jsonpath-filtering-enabled: ${GALAXY_FEATURE_JSONPATH_FILTERING_ENABLED:false}
   feature-jsonpath-filtering-event-types: ${GALAXY_FEATURE_JSONPATH_FILTERING_EVENT_TYPES:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,6 +56,8 @@ galaxy:
   subscription-max-threadpool-size: ${GALAXY_SUBSCRIPTION_MAX_THREADPOOL_SIZE:50}
   subscription-queue-capacity: ${GALAXY_SUBSCRIPTION_QUEUE_CAPACITY:15000}
   nack-sleep-duration-ms: ${GALAXY_NACK_SLEEP_DURATION_MS:5000}
+  backpressure-resume-check-interval-ms: ${GALAXY_BACKPRESSURE_RESUME_CHECK_INTERVAL_MS:1000}
+  backpressure-resume-threshold: ${GALAXY_BACKPRESSURE_RESUME_THRESHOLD:0.5}
   default-environment: ${GALAXY_DEFAULT_ENVIRONMENT:default}
   feature-jsonpath-filtering-enabled: ${GALAXY_FEATURE_JSONPATH_FILTERING_ENABLED:false}
   feature-jsonpath-filtering-event-types: ${GALAXY_FEATURE_JSONPATH_FILTERING_EVENT_TYPES:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,11 +50,11 @@ pandora:
 
 galaxy:
   batch-core-threadpool-size: ${GALAXY_CORE_THREADPOOL_SIZE:10}
-  batch-max-threadpool-size: ${GALAXY_MAX_THREADPOOL_SIZE:50}
-  batch-queue-capacity: ${GALAXY_BATCH_QUEUE_CAPACITY:100}
+  batch-max-threadpool-size: ${GALAXY_MAX_THREADPOOL_SIZE:40}
+  batch-queue-capacity: ${GALAXY_BATCH_QUEUE_CAPACITY:1400}
   subscription-core-threadpool-size: ${GALAXY_SUBSCRIPTION_CORE_THREADPOOL_SIZE:20}
   subscription-max-threadpool-size: ${GALAXY_SUBSCRIPTION_MAX_THREADPOOL_SIZE:50}
-  subscription-queue-capacity: ${GALAXY_SUBSCRIPTION_QUEUE_CAPACITY:200}
+  subscription-queue-capacity: ${GALAXY_SUBSCRIPTION_QUEUE_CAPACITY:15000}
   nack-sleep-duration-ms: ${GALAXY_NACK_SLEEP_DURATION_MS:5000}
   default-environment: ${GALAXY_DEFAULT_ENVIRONMENT:default}
   feature-jsonpath-filtering-enabled: ${GALAXY_FEATURE_JSONPATH_FILTERING_ENABLED:false}
@@ -71,7 +71,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus,heapdump,shutdown
+        include: health,info,prometheus
   endpoint:
     health:
       show-details: always

--- a/src/test/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListenerTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListenerTest.java
@@ -1,0 +1,148 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.galaxy.kafka;
+
+import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
+import de.telekom.horizon.galaxy.config.GalaxyConfig;
+import de.telekom.horizon.galaxy.model.PublishedMessageTaskResult;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PublishedMessageListenerTest {
+
+    private PublishedMessageTaskFactory factory;
+    private HorizonTracer tracer;
+    private GalaxyConfig galaxyConfig;
+    private SimpleMeterRegistry meterRegistry;
+    private Acknowledgment acknowledgment;
+    private PublishedMessageListener listener;
+
+    @BeforeEach
+    void setUp() {
+        factory = mock(PublishedMessageTaskFactory.class);
+        tracer = mock(HorizonTracer.class);
+        galaxyConfig = new GalaxyConfig();
+        galaxyConfig.setBatchCoreThreadPoolSize(2);
+        galaxyConfig.setBatchMaxThreadPoolSize(2);
+        galaxyConfig.setBatchQueueCapacity(5);
+        galaxyConfig.setNackSleepDurationMs(1000);
+        meterRegistry = new SimpleMeterRegistry();
+        acknowledgment = mock(Acknowledgment.class);
+
+        // Make tracer.withCurrentTraceContext pass through the callable
+        when(tracer.withCurrentTraceContext(any(Callable.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        listener = new PublishedMessageListener(factory, tracer, galaxyConfig, meterRegistry);
+    }
+
+    @Test
+    void onMessageShouldAcknowledgeWhenAllTasksSucceed() {
+        var record = new ConsumerRecord<>("topic", 0, 0L, "key", "value");
+        var task = mock(PublishedMessageTask.class);
+        when(factory.newTask(any())).thenReturn(task);
+        when(task.call()).thenReturn(new PublishedMessageTaskResult(true));
+
+        listener.onMessage(List.of(record), acknowledgment);
+
+        verify(acknowledgment).acknowledge();
+        verify(acknowledgment, never()).nack(anyInt(), any(Duration.class));
+    }
+
+    @Test
+    void onMessageShouldNackOnTaskFailure() {
+        var record = new ConsumerRecord<>("topic", 0, 0L, "key", "value");
+        var task = mock(PublishedMessageTask.class);
+        when(factory.newTask(any())).thenReturn(task);
+        when(task.call()).thenReturn(new PublishedMessageTaskResult(false));
+
+        listener.onMessage(List.of(record), acknowledgment);
+
+        verify(acknowledgment, never()).acknowledge();
+        verify(acknowledgment).nack(eq(0), any(Duration.class));
+    }
+
+    @Test
+    void onMessageShouldNackOnRejection() {
+        // Fill the thread pool to force rejection
+        galaxyConfig.setBatchCoreThreadPoolSize(1);
+        galaxyConfig.setBatchMaxThreadPoolSize(1);
+        galaxyConfig.setBatchQueueCapacity(0);
+        var smallPoolListener = new PublishedMessageListener(factory, tracer, galaxyConfig, meterRegistry);
+
+        // Create a blocking task that occupies the single thread
+        var blockingTask = mock(PublishedMessageTask.class);
+        when(factory.newTask(any())).thenReturn(blockingTask);
+        when(blockingTask.call()).thenAnswer(invocation -> {
+            Thread.sleep(2000);
+            return new PublishedMessageTaskResult(true);
+        });
+
+        var record1 = new ConsumerRecord<>("topic", 0, 0L, "key1", "value1");
+        var record2 = new ConsumerRecord<>("topic", 0, 1L, "key2", "value2");
+        var record3 = new ConsumerRecord<>("topic", 0, 2L, "key3", "value3");
+
+        smallPoolListener.onMessage(List.of(record1, record2, record3), acknowledgment);
+
+        verify(acknowledgment, never()).acknowledge();
+        verify(acknowledgment).nack(anyInt(), any(Duration.class));
+        assertTrue(meterRegistry.get("pubsub.batch.threadpool.saturated").counter().count() > 0);
+    }
+
+    @Test
+    void onMessageShouldNackAtEarliestFailureWhenBothRejectionAndTaskFailure() {
+        // Use a pool that can accept exactly 1 task (queue=0, 1 thread)
+        galaxyConfig.setBatchCoreThreadPoolSize(1);
+        galaxyConfig.setBatchMaxThreadPoolSize(1);
+        galaxyConfig.setBatchQueueCapacity(0);
+        var smallPoolListener = new PublishedMessageListener(factory, tracer, galaxyConfig, meterRegistry);
+
+        // First task fails, second gets rejected
+        var failingTask = mock(PublishedMessageTask.class);
+        when(factory.newTask(any())).thenReturn(failingTask);
+        when(failingTask.call()).thenAnswer(invocation -> {
+            Thread.sleep(500);
+            return new PublishedMessageTaskResult(false);
+        });
+
+        var record1 = new ConsumerRecord<>("topic", 0, 0L, "key1", "value1");
+        var record2 = new ConsumerRecord<>("topic", 0, 1L, "key2", "value2");
+
+        smallPoolListener.onMessage(List.of(record1, record2), acknowledgment);
+
+        // Should nack at index 0 (task failure at 0 is earlier than rejection at 1)
+        verify(acknowledgment).nack(eq(0), any(Duration.class));
+    }
+
+    @Test
+    void onMessageShouldIncrementNackCounterOnFailure() {
+        var record = new ConsumerRecord<>("topic", 0, 0L, "key", "value");
+        var task = mock(PublishedMessageTask.class);
+        when(factory.newTask(any())).thenReturn(task);
+        when(task.call()).thenReturn(new PublishedMessageTaskResult(false));
+
+        listener.onMessage(List.of(record), acknowledgment);
+
+        assertEquals(1.0, meterRegistry.get("pubsub.kafka.listener.nacks").counter().count());
+        assertEquals(1.0, meterRegistry.get("pubsub.kafka.listener.nacks.task_failure").counter().count());
+    }
+
+    @Test
+    void onMessageShouldAcknowledgeEmptyBatch() {
+        listener.onMessage(List.of(), acknowledgment);
+
+        verify(acknowledgment).acknowledge();
+    }
+}

--- a/src/test/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListenerTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/kafka/PublishedMessageListenerTest.java
@@ -98,7 +98,6 @@ class PublishedMessageListenerTest {
 
         verify(acknowledgment, never()).acknowledge();
         verify(acknowledgment).nack(anyInt(), any(Duration.class));
-        assertTrue(meterRegistry.get("pubsub.batch.threadpool.saturated").counter().count() > 0);
     }
 
     @Test

--- a/src/test/java/de/telekom/horizon/galaxy/service/BackpressureHandlerTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/BackpressureHandlerTest.java
@@ -5,10 +5,14 @@
 package de.telekom.horizon.galaxy.service;
 
 import de.telekom.horizon.galaxy.config.GalaxyConfig;
+import de.telekom.horizon.galaxy.kafka.PublishedMessageListener;
+import de.telekom.horizon.galaxy.kafka.PublishedMessageTaskFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -23,21 +27,30 @@ class BackpressureHandlerTest {
     private MeterRegistry meterRegistry;
     private BackpressureHandler handler;
 
+    GalaxyConfig galaxyConfig = new GalaxyConfig();
+
     @SuppressWarnings("unchecked")
     private final ConcurrentMessageListenerContainer<String, String> container = mock(ConcurrentMessageListenerContainer.class);
+
+    private final PublishedMessageTaskFactory publishedMessageTaskFactory = mock(PublishedMessageTaskFactory.class);
+    private final PublishedMessageListener publishedMessageListener = mock(PublishedMessageListener.class);
+
+    private final ThreadPoolTaskExecutor batchExecutor = createExecutorWithQueueUsage(0.3);
+    private final ThreadPoolTaskExecutor subscriptionExecutor = createExecutorWithQueueUsage(0.7);
 
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        var galaxyConfig = new GalaxyConfig();
         galaxyConfig.setBackpressureResumeThreshold(0.5);
-        handler = new BackpressureHandler(meterRegistry, galaxyConfig);
+
+        when(publishedMessageListener.getTaskExecutor()).thenReturn(batchExecutor);
+        when(publishedMessageTaskFactory.getSubscriptionTaskExecutor()).thenReturn(subscriptionExecutor);
+
+        handler = new BackpressureHandler(meterRegistry, galaxyConfig, container, publishedMessageTaskFactory, publishedMessageListener);
     }
 
     @Test
     void pauseShouldPauseContainerAndSetState() {
-        handler.setListenerContainer(container);
-
         handler.pause();
 
         assertTrue(handler.isPaused());
@@ -48,8 +61,6 @@ class BackpressureHandlerTest {
 
     @Test
     void pauseCalledTwiceShouldOnlyPauseOnce() {
-        handler.setListenerContainer(container);
-
         handler.pause();
         handler.pause();
 
@@ -59,7 +70,6 @@ class BackpressureHandlerTest {
 
     @Test
     void resumeShouldResumeContainerAndClearState() {
-        handler.setListenerContainer(container);
         handler.pause();
 
         handler.resume();
@@ -71,7 +81,6 @@ class BackpressureHandlerTest {
 
     @Test
     void resumeCalledTwiceShouldOnlyResumeOnce() {
-        handler.setListenerContainer(container);
         handler.pause();
 
         handler.resume();
@@ -82,19 +91,10 @@ class BackpressureHandlerTest {
 
     @Test
     void resumeWithoutPauseShouldDoNothing() {
-        handler.setListenerContainer(container);
-
         handler.resume();
 
         assertFalse(handler.isPaused());
         verify(container, never()).resume();
-    }
-
-    @Test
-    void pauseWithoutContainerShouldNotThrow() {
-        // No container set
-        assertDoesNotThrow(() -> handler.pause());
-        assertFalse(handler.isPaused());
     }
 
     @Test
@@ -111,8 +111,6 @@ class BackpressureHandlerTest {
 
     @Test
     void gaugeReflectsPausedState() {
-        handler.setListenerContainer(container);
-
         assertEquals(0.0, meterRegistry.get("pubsub.kafka.listener.paused").gauge().value());
 
         handler.pause();
@@ -124,7 +122,6 @@ class BackpressureHandlerTest {
 
     @Test
     void rejectedExecutionShouldPauseAndThrow() {
-        handler.setListenerContainer(container);
         var runnable = mock(Runnable.class);
         var executor = mock(ThreadPoolExecutor.class);
 
@@ -135,88 +132,38 @@ class BackpressureHandlerTest {
 
     @Test
     void checkAndResumeShouldSkipWhenNotPaused() {
-        handler.setListenerContainer(container);
-
         handler.checkAndResume();
 
         verify(container, never()).resume();
     }
 
-    @Test
-    void checkAndResumeShouldResumeWhenBothPoolsBelowThreshold() {
-        handler.setListenerContainer(container);
-        handler.pause();
+    @ParameterizedTest(name = "{0}")
+    @CsvSource({
+            "Resume when both pools below threshold, 0.3, 0.2, true",   // Both below threshold
+            "Do not resume when batch-pool above threshold, 0.8, 0.2, false",  // Batch above threshold
+            "Do not resume when subscription-pool above threshold, 0.3, 0.7, false",  // Subscription above threshold
+            "Resume when both pools exactly at threshold, 0.5, 0.5, true"    // Both exactly at threshold
+    })
+    void checkAndResumeShouldHandleThresholds(String displayName, double batchUsage, double subscriptionUsage, boolean shouldResume) {
+        var newBatchExecutor = createExecutorWithQueueUsage(batchUsage);
+        var newSubscriptionExecutor = createExecutorWithQueueUsage(subscriptionUsage);
 
-        var batchExecutor = createExecutorWithQueueUsage(0.3);
-        var subscriptionExecutor = createExecutorWithQueueUsage(0.2);
-        handler.setBatchExecutor(batchExecutor);
-        handler.setSubscriptionExecutor(subscriptionExecutor);
+        when(publishedMessageListener.getTaskExecutor()).thenReturn(newBatchExecutor);
+        when(publishedMessageTaskFactory.getSubscriptionTaskExecutor()).thenReturn(newSubscriptionExecutor);
+
+        handler = new BackpressureHandler(meterRegistry, galaxyConfig, container, publishedMessageTaskFactory, publishedMessageListener);
+
+        handler.pause();
 
         handler.checkAndResume();
 
-        assertFalse(handler.isPaused());
-        verify(container).resume();
-    }
-
-    @Test
-    void checkAndResumeShouldNotResumeWhenBatchPoolAboveThreshold() {
-        handler.setListenerContainer(container);
-        handler.pause();
-
-        var batchExecutor = createExecutorWithQueueUsage(0.8);
-        var subscriptionExecutor = createExecutorWithQueueUsage(0.2);
-        handler.setBatchExecutor(batchExecutor);
-        handler.setSubscriptionExecutor(subscriptionExecutor);
-
-        handler.checkAndResume();
-
-        assertTrue(handler.isPaused());
-        verify(container, never()).resume();
-    }
-
-    @Test
-    void checkAndResumeShouldNotResumeWhenSubscriptionPoolAboveThreshold() {
-        handler.setListenerContainer(container);
-        handler.pause();
-
-        var batchExecutor = createExecutorWithQueueUsage(0.3);
-        var subscriptionExecutor = createExecutorWithQueueUsage(0.7);
-        handler.setBatchExecutor(batchExecutor);
-        handler.setSubscriptionExecutor(subscriptionExecutor);
-
-        handler.checkAndResume();
-
-        assertTrue(handler.isPaused());
-        verify(container, never()).resume();
-    }
-
-    @Test
-    void checkAndResumeShouldResumeWhenBothPoolsExactlyAtThreshold() {
-        handler.setListenerContainer(container);
-        handler.pause();
-
-        var batchExecutor = createExecutorWithQueueUsage(0.5);
-        var subscriptionExecutor = createExecutorWithQueueUsage(0.5);
-        handler.setBatchExecutor(batchExecutor);
-        handler.setSubscriptionExecutor(subscriptionExecutor);
-
-        handler.checkAndResume();
-
-        assertFalse(handler.isPaused());
-        verify(container).resume();
-    }
-
-    @Test
-    void checkAndResumeShouldHandleNullExecutors() {
-        handler.setListenerContainer(container);
-        handler.pause();
-        // Don't set any executors — they remain null
-
-        handler.checkAndResume();
-
-        // Null executors return 0.0 usage, which is below threshold → resume
-        assertFalse(handler.isPaused());
-        verify(container).resume();
+        if (shouldResume) {
+            assertFalse(handler.isPaused());
+            verify(container).resume();
+        } else {
+            assertTrue(handler.isPaused());
+            verify(container, never()).resume();
+        }
     }
 
     private ThreadPoolTaskExecutor createExecutorWithQueueUsage(double ratio) {
@@ -233,7 +180,10 @@ class BackpressureHandlerTest {
         // Fill queue to desired ratio
         for (int i = 0; i < queuedItems; i++) {
             executor.getThreadPoolExecutor().getQueue().add(() -> {
-                try { Thread.sleep(60000); } catch (InterruptedException ignored) {}
+                try {
+                    Thread.sleep(60000);
+                } catch (InterruptedException ignored) {
+                }
             });
         }
 

--- a/src/test/java/de/telekom/horizon/galaxy/service/BackpressureHandlerTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/BackpressureHandlerTest.java
@@ -1,0 +1,242 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.galaxy.service;
+
+import de.telekom.horizon.galaxy.config.GalaxyConfig;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BackpressureHandlerTest {
+
+    private MeterRegistry meterRegistry;
+    private BackpressureHandler handler;
+
+    @SuppressWarnings("unchecked")
+    private final ConcurrentMessageListenerContainer<String, String> container = mock(ConcurrentMessageListenerContainer.class);
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        var galaxyConfig = new GalaxyConfig();
+        galaxyConfig.setBackpressureResumeThreshold(0.5);
+        handler = new BackpressureHandler(meterRegistry, galaxyConfig);
+    }
+
+    @Test
+    void pauseShouldPauseContainerAndSetState() {
+        handler.setListenerContainer(container);
+
+        handler.pause();
+
+        assertTrue(handler.isPaused());
+        verify(container).pause();
+        assertEquals(1.0, meterRegistry.get("pubsub.kafka.listener.pause.triggered").counter().count());
+        assertEquals(1.0, meterRegistry.get("pubsub.kafka.listener.paused").gauge().value());
+    }
+
+    @Test
+    void pauseCalledTwiceShouldOnlyPauseOnce() {
+        handler.setListenerContainer(container);
+
+        handler.pause();
+        handler.pause();
+
+        verify(container, times(1)).pause();
+        assertEquals(1.0, meterRegistry.get("pubsub.kafka.listener.pause.triggered").counter().count());
+    }
+
+    @Test
+    void resumeShouldResumeContainerAndClearState() {
+        handler.setListenerContainer(container);
+        handler.pause();
+
+        handler.resume();
+
+        assertFalse(handler.isPaused());
+        verify(container).resume();
+        assertEquals(0.0, meterRegistry.get("pubsub.kafka.listener.paused").gauge().value());
+    }
+
+    @Test
+    void resumeCalledTwiceShouldOnlyResumeOnce() {
+        handler.setListenerContainer(container);
+        handler.pause();
+
+        handler.resume();
+        handler.resume();
+
+        verify(container, times(1)).resume();
+    }
+
+    @Test
+    void resumeWithoutPauseShouldDoNothing() {
+        handler.setListenerContainer(container);
+
+        handler.resume();
+
+        assertFalse(handler.isPaused());
+        verify(container, never()).resume();
+    }
+
+    @Test
+    void pauseWithoutContainerShouldNotThrow() {
+        // No container set
+        assertDoesNotThrow(() -> handler.pause());
+        assertFalse(handler.isPaused());
+    }
+
+    @Test
+    void resumeWithoutContainerShouldNotThrow() {
+        // No container set
+        assertDoesNotThrow(() -> handler.resume());
+        assertFalse(handler.isPaused());
+    }
+
+    @Test
+    void isPausedShouldReturnFalseInitially() {
+        assertFalse(handler.isPaused());
+    }
+
+    @Test
+    void gaugeReflectsPausedState() {
+        handler.setListenerContainer(container);
+
+        assertEquals(0.0, meterRegistry.get("pubsub.kafka.listener.paused").gauge().value());
+
+        handler.pause();
+        assertEquals(1.0, meterRegistry.get("pubsub.kafka.listener.paused").gauge().value());
+
+        handler.resume();
+        assertEquals(0.0, meterRegistry.get("pubsub.kafka.listener.paused").gauge().value());
+    }
+
+    @Test
+    void rejectedExecutionShouldPauseAndThrow() {
+        handler.setListenerContainer(container);
+        var runnable = mock(Runnable.class);
+        var executor = mock(ThreadPoolExecutor.class);
+
+        assertThrows(RejectedExecutionException.class, () -> handler.rejectedExecution(runnable, executor));
+        assertTrue(handler.isPaused());
+        verify(container).pause();
+    }
+
+    @Test
+    void checkAndResumeShouldSkipWhenNotPaused() {
+        handler.setListenerContainer(container);
+
+        handler.checkAndResume();
+
+        verify(container, never()).resume();
+    }
+
+    @Test
+    void checkAndResumeShouldResumeWhenBothPoolsBelowThreshold() {
+        handler.setListenerContainer(container);
+        handler.pause();
+
+        var batchExecutor = createExecutorWithQueueUsage(0.3);
+        var subscriptionExecutor = createExecutorWithQueueUsage(0.2);
+        handler.setBatchExecutor(batchExecutor);
+        handler.setSubscriptionExecutor(subscriptionExecutor);
+
+        handler.checkAndResume();
+
+        assertFalse(handler.isPaused());
+        verify(container).resume();
+    }
+
+    @Test
+    void checkAndResumeShouldNotResumeWhenBatchPoolAboveThreshold() {
+        handler.setListenerContainer(container);
+        handler.pause();
+
+        var batchExecutor = createExecutorWithQueueUsage(0.8);
+        var subscriptionExecutor = createExecutorWithQueueUsage(0.2);
+        handler.setBatchExecutor(batchExecutor);
+        handler.setSubscriptionExecutor(subscriptionExecutor);
+
+        handler.checkAndResume();
+
+        assertTrue(handler.isPaused());
+        verify(container, never()).resume();
+    }
+
+    @Test
+    void checkAndResumeShouldNotResumeWhenSubscriptionPoolAboveThreshold() {
+        handler.setListenerContainer(container);
+        handler.pause();
+
+        var batchExecutor = createExecutorWithQueueUsage(0.3);
+        var subscriptionExecutor = createExecutorWithQueueUsage(0.7);
+        handler.setBatchExecutor(batchExecutor);
+        handler.setSubscriptionExecutor(subscriptionExecutor);
+
+        handler.checkAndResume();
+
+        assertTrue(handler.isPaused());
+        verify(container, never()).resume();
+    }
+
+    @Test
+    void checkAndResumeShouldResumeWhenBothPoolsExactlyAtThreshold() {
+        handler.setListenerContainer(container);
+        handler.pause();
+
+        var batchExecutor = createExecutorWithQueueUsage(0.5);
+        var subscriptionExecutor = createExecutorWithQueueUsage(0.5);
+        handler.setBatchExecutor(batchExecutor);
+        handler.setSubscriptionExecutor(subscriptionExecutor);
+
+        handler.checkAndResume();
+
+        assertFalse(handler.isPaused());
+        verify(container).resume();
+    }
+
+    @Test
+    void checkAndResumeShouldHandleNullExecutors() {
+        handler.setListenerContainer(container);
+        handler.pause();
+        // Don't set any executors — they remain null
+
+        handler.checkAndResume();
+
+        // Null executors return 0.0 usage, which is below threshold → resume
+        assertFalse(handler.isPaused());
+        verify(container).resume();
+    }
+
+    private ThreadPoolTaskExecutor createExecutorWithQueueUsage(double ratio) {
+        // Create a real executor to avoid complex mocking of getThreadPoolExecutor().getQueue()
+        int capacity = 100;
+        int queuedItems = (int) (capacity * ratio);
+
+        var executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(capacity);
+        executor.afterPropertiesSet();
+
+        // Fill queue to desired ratio
+        for (int i = 0; i < queuedItems; i++) {
+            executor.getThreadPoolExecutor().getQueue().add(() -> {
+                try { Thread.sleep(60000); } catch (InterruptedException ignored) {}
+            });
+        }
+
+        return executor;
+    }
+}

--- a/src/test/java/de/telekom/horizon/galaxy/service/BackpressureIntegrationTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/service/BackpressureIntegrationTest.java
@@ -1,0 +1,73 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.galaxy.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.telekom.eni.pandora.horizon.model.event.SubscriptionEventMessage;
+import de.telekom.horizon.galaxy.utils.AbstractIntegrationTest;
+import de.telekom.horizon.galaxy.utils.HazelcastTestInstance;
+import de.telekom.horizon.galaxy.utils.HorizonTestHelper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(HazelcastTestInstance.class)
+class BackpressureIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private BackpressureHandler backpressureHandler;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String TEST_ENVIRONMENT = "playground";
+
+    @BeforeEach
+    void resetBackpressure() {
+        if (backpressureHandler.isPaused()) {
+            backpressureHandler.resume();
+        }
+    }
+
+    @Test
+    void backpressurePauseShouldStopConsumptionAndResumeAfterRecovery() throws Exception {
+        // given: a subscription for the event type
+        var sub = HorizonTestHelper.createDefaultSubscriptionResource(TEST_ENVIRONMENT, getEventType());
+        when(subscriptionCacheMock.getSubscriptionsForEnvironmentAndEventType(TEST_ENVIRONMENT, getEventType()))
+                .thenReturn(List.of(sub));
+
+        // when: simulate backpressure (this is what RejectedExecutionHandler.rejectedExecution does)
+        backpressureHandler.pause();
+        assertTrue(backpressureHandler.isPaused());
+
+        // publish an event while paused
+        var message = getPublishedEventMessage("{\"data\": \"backpressure-test\"}");
+        simulateNewPublishedEvent(message);
+
+        // then: no message should arrive while paused
+        ConsumerRecord<String, String> blocked = pollForRecord(2, TimeUnit.SECONDS);
+        assertNull(blocked, "No message should be received while consumer is paused");
+
+        // when: resume (this is what checkAndResume does when pools recover)
+        backpressureHandler.resume();
+        assertFalse(backpressureHandler.isPaused());
+
+        // then: message should be processed after resume
+        ConsumerRecord<String, String> received = pollForRecord(10, TimeUnit.SECONDS);
+        assertNotNull(received, "Event should be received after backpressure recovery");
+
+        SubscriptionEventMessage multiplexedEvent = objectMapper.readValue(received.value(), SubscriptionEventMessage.class);
+        assertEquals(getEventType(), multiplexedEvent.getEvent().getType());
+        assertEquals(message.getUuid(), multiplexedEvent.getMultiplexedFrom());
+    }
+}

--- a/src/test/java/de/telekom/horizon/galaxy/utils/AbstractIntegrationTest.java
+++ b/src/test/java/de/telekom/horizon/galaxy/utils/AbstractIntegrationTest.java
@@ -112,6 +112,8 @@ public abstract class AbstractIntegrationTest {
         registry.add("horizon.cache.kubernetesServiceDns", () -> "");
         registry.add("horizon.cache.deDuplication.enabled", () -> true);
         registry.add("kubernetes.enabled", () -> false);
+        // Disable automatic backpressure monitor scheduling for integration tests
+        registry.add("galaxy.backpressure-resume-check-interval-ms", () -> 999999999);
     }
 
     public ConsumerRecord<String, String> pollForRecord(int timeout, TimeUnit timeUnit) throws InterruptedException {


### PR DESCRIPTION
…ssure handling

BREAKING CHANGE: Thread pool configuration properties renamed and new properties added

Branched from 5.1.0 as currently in production. Additionally based on current problem situation removing batch processing completely with 76f8d81148d819478e441020b581797801ae3722 is potentially then comparing apples with bananas. So this branch has to be compared against main and 5.1.0 it self in a load test scenario.

Points introduced here to adress behaviour when experiencing slowed down kafka write performance under load (Additionally creating a predictable behaviour under load or slow kafka):

- Eliminated per-task thread pool creation (was creating 100+ pools)
- Implement shared thread pool architecture for batch and subscription processing
- Add bounded queue capacity to prevent OOM under load (batch: 100, subscription: 200 -> but numbers to open as most likely one galaxy instance will process only a few partitions or just one) -> pause listener when pools are saturated -> backpressure -> check every 1s per default if saturation is gone again to resume listening again. This significantly reduces the load on kafka broker during backpressuring (prevent nack loops)
- Replace CallerRunsPolicy with AbortPolicy to prevent Kafka consumer thread blocking
- Introduced metrics for threadpoolexecutors including counter metric as event to increase while threadtools are saturated -> good for monitoring and at there is no view on that at all
