### PR TITLE
fix: replace payload_size percentile-histogram with fixed SLO buckets…

### DIFF
--- a/src/main/java/de/telekom/horizon/galaxy/cache/PayloadSizeHistogramCache.java
+++ b/src/main/java/de/telekom/horizon/galaxy/cache/PayloadSizeHistogramCache.java
@@ -61,7 +61,7 @@ public class PayloadSizeHistogramCache {
         var key = keyBuilder.toString();
 
         cache.computeIfAbsent(key, k -> DistributionSummary.builder(metricName)
-                .publishPercentileHistogram()
+                .serviceLevelObjectives(1024, 4096, 16384, 65536, 262144, 524288, 1048576)
                 .baseUnit("bytes")
                 .tags(buildTagsFromMessage(message))
                 .register(metricsHelper.getRegistry()));


### PR DESCRIPTION
… (max 1MB)

Replace .publishPercentileHistogram() (276 exponential buckets from 1B to 1.15EB) with 6 fixed SLO buckets: 1KB, 4KB, 16KB, 64KB, 256KB, 1MB.

This reduces payload_size histogram bucket series from ~50k to ~2k per pod based on a preprod series sample (>95% reduction), addressing the single largest cardinality issue across all Horizon components.